### PR TITLE
fs_mgr: Don't run clean_scratch_files on non-dynamic devices

### DIFF
--- a/fs_mgr/clean_scratch_files.rc
+++ b/fs_mgr/clean_scratch_files.rc
@@ -1,2 +1,2 @@
-on post-fs-data && property:ro.debuggable=1
+on post-fs-data && property:ro.debuggable=1 && property:ro.boot.dynamic_partitions=true
     exec_background - root root -- /system/bin/clean_scratch_files


### PR DESCRIPTION
* This results in a metric ton of denials on some devices and
  eats up valuable resources on boot, plus there's 0 need for it,
  so kill it.

Change-Id: Ic52d5b3f06724430e9505345024cf0041b37ca49